### PR TITLE
Branch prediction

### DIFF
--- a/rtl/PUC_RS5.sv
+++ b/rtl/PUC_RS5.sv
@@ -63,8 +63,8 @@ module PUC_RS5
     logic   [31:0]  jump_target;
     /* verilator lint_off UNUSEDSIGNAL */
     logic   [31:0]  mem_read_address_int;
-    /* verilator lint_on UNUSEDSIGNAL */
     logic   [31:0]  mem_write_address_int;
+    /* verilator lint_on UNUSEDSIGNAL */
 
 `ifdef BRANCH_PREDICTION
     logic           predict_branch_taken;

--- a/rtl/PUC_RS5.sv
+++ b/rtl/PUC_RS5.sv
@@ -37,7 +37,7 @@
 
 // `define PROTO 1
 // `define DEBUG 1
-// `define BRANCH_PREDICTION 1
+`define BRANCH_PREDICTION 1
 
 module PUC_RS5 
     import my_pkg::*;

--- a/rtl/PUC_RS5.sv
+++ b/rtl/PUC_RS5.sv
@@ -27,6 +27,7 @@
 `include "../rtl/xus/LSUnit.sv"
 `include "../rtl/xus/shiftUnit.sv"
 `include "../rtl/fetch.sv"
+`include "../rtl/branchPredict.sv"
 `include "../rtl/decode.sv"
 `include "../rtl/execute.sv"
 `include "../rtl/retire.sv"
@@ -36,7 +37,7 @@
 
 // `define PROTO 1
 // `define DEBUG 1
-
+// `define BRANCH_PREDICTION 1
 
 module PUC_RS5 
     import my_pkg::*;
@@ -69,8 +70,10 @@ module PUC_RS5
     /* verilator lint_on UNUSEDSIGNAL */
     logic   [31:0]  mem_write_address_int;
 
+`ifdef BRANCH_PREDICTION
     logic           predict_branch_taken;
     logic   [31:0]  predict_branch_pc;
+`endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Decoder signals
@@ -99,7 +102,10 @@ module PUC_RS5
     logic   [31:0]  pc_execute;
     logic    [2:0]  tag_execute;
     logic           exception_execute;
+
+`ifdef BRANCH_PREDICTION
     logic           predicted_branch_execute;
+`endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Retire signals
@@ -117,8 +123,10 @@ module PUC_RS5
     logic           exception_retire;
     /* verilator lint_on UNUSEDSIGNAL */
     logic           killed;
-    logic           predicted_branch_retire;
 
+`ifdef BRANCH_PREDICTION
+    logic           predicted_branch_retire;
+`endif
 
 //////////////////////////////////////////////////////////////////////////////
 // CSR Bank signals
@@ -145,8 +153,10 @@ module PUC_RS5
         .hazard_i(hazard), 
         .jump_i(jump), 
         .jump_target_i(jump_target),
+    `ifdef BRANCH_PREDICTION
         .predict_branch_taken_i(predict_branch_taken),
         .predict_branch_pc_i(predict_branch_pc),
+    `endif
         .instruction_address_o(instruction_address_o), 
         .pc_o(pc_decode), 
         .tag_o(tag_decode),
@@ -178,6 +188,11 @@ module PUC_RS5
         .tag_i(tag_decode), 
         .rs1_data_read_i(rs1_data_read), 
         .rs2_data_read_i(rs2_data_read), 
+    `ifdef BRANCH_PREDICTION
+        .predicted_branch_o(predicted_branch_execute),
+        .predict_branch_taken_o(predict_branch_taken),
+        .predict_branch_pc_o(predict_branch_pc),
+    `endif
         .rs1_o(rs1), 
         .rs2_o(rs2), 
         .rd_o(rd), 
@@ -189,10 +204,7 @@ module PUC_RS5
         .tag_o(tag_execute), 
         .instruction_operation_o(instruction_operation_execute), 
         .hazard_o(hazard), 
-        .exception_o(exception_execute),
-        .predicted_branch_o(predicted_branch_execute),
-        .predict_branch_taken_o(predict_branch_taken),
-        .predict_branch_pc_o(predict_branch_pc)
+        .exception_o(exception_execute)
     );
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -256,7 +268,9 @@ module PUC_RS5
         .result_o(result_retire), 
         .tag_o(tag_retire), 
         .jump_o(jump_retire),
+    `ifdef BRANCH_PREDICTION
         .predicted_branch_o(predicted_branch_retire),
+    `endif
         .write_enable_o(we_retire),
         .mem_read_address_o(mem_read_address_int), 
         .mem_write_enable_o(mem_write_enable_retire),
@@ -281,7 +295,9 @@ module PUC_RS5
         .pc_i(pc_retire),
         .results_i(result_retire), 
         .tag_i(tag_retire),
+    `ifdef BRANCH_PREDICTION
         .predicted_branch_i(predicted_branch_retire),
+    `endif
         .mem_write_enable_i(mem_write_enable_retire),
         .write_enable_i(we_retire),
         .jump_i(jump_retire), 

--- a/rtl/PUC_RS5.sv
+++ b/rtl/PUC_RS5.sv
@@ -172,6 +172,7 @@ module PUC_RS5
         .clk(clk), 
         .reset(reset),
         .stall(stall),
+        .killed_i(killed),
         .instruction_i(instruction_i), 
         .pc_i(pc_decode), 
         .tag_i(tag_decode), 

--- a/rtl/PUC_RS5.sv
+++ b/rtl/PUC_RS5.sv
@@ -69,6 +69,7 @@ module PUC_RS5
 `ifdef BRANCH_PREDICTION
     logic           predict_branch_taken;
     logic   [31:0]  predict_branch_pc;
+    logic           wrong_prediction;
 `endif
 
 //////////////////////////////////////////////////////////////////////////////
@@ -152,6 +153,7 @@ module PUC_RS5
     `ifdef BRANCH_PREDICTION
         .predict_branch_taken_i(predict_branch_taken),
         .predict_branch_pc_i(predict_branch_pc),
+        .wrong_prediction_i(wrong_prediction),
     `endif
         .instruction_address_o(instruction_address_o), 
         .pc_o(pc_decode), 
@@ -185,6 +187,7 @@ module PUC_RS5
         .rs2_data_read_i(rs2_data_read), 
     `ifdef BRANCH_PREDICTION
         .killed_i(killed),
+        .jump_i(jump),
         .predicted_branch_o(predicted_branch_execute),
         .predict_branch_taken_o(predict_branch_taken),
         .predict_branch_pc_o(predict_branch_pc),
@@ -293,6 +296,7 @@ module PUC_RS5
         .tag_i(tag_retire),
     `ifdef BRANCH_PREDICTION
         .predicted_branch_i(predicted_branch_retire),
+        .wrong_prediction_o(wrong_prediction),
     `endif
         .mem_write_enable_i(mem_write_enable_retire),
         .write_enable_i(we_retire),

--- a/rtl/PUC_RS5.sv
+++ b/rtl/PUC_RS5.sv
@@ -35,10 +35,6 @@
 `include "../rtl/CSRBank.sv"
 */
 
-// `define PROTO 1
-// `define DEBUG 1
-`define BRANCH_PREDICTION 1
-
 module PUC_RS5 
     import my_pkg::*;
 (
@@ -182,13 +178,13 @@ module PUC_RS5
         .clk(clk), 
         .reset(reset),
         .stall(stall),
-        .killed_i(killed),
         .instruction_i(instruction_i), 
         .pc_i(pc_decode), 
         .tag_i(tag_decode), 
         .rs1_data_read_i(rs1_data_read), 
         .rs2_data_read_i(rs2_data_read), 
     `ifdef BRANCH_PREDICTION
+        .killed_i(killed),
         .predicted_branch_o(predicted_branch_execute),
         .predict_branch_taken_o(predict_branch_taken),
         .predict_branch_pc_o(predict_branch_pc),
@@ -262,15 +258,15 @@ module PUC_RS5
         .instruction_operation_i(instruction_operation_execute), 
         .instruction_o(instruction_retire), 
         .tag_i(tag_execute), 
+    `ifdef BRANCH_PREDICTION
         .predicted_branch_i(predicted_branch_execute),
+        .predicted_branch_o(predicted_branch_retire),
+    `endif
         .instruction_operation_o(instruction_operation_retire), 
         .pc_o(pc_retire), 
         .result_o(result_retire), 
         .tag_o(tag_retire), 
         .jump_o(jump_retire),
-    `ifdef BRANCH_PREDICTION
-        .predicted_branch_o(predicted_branch_retire),
-    `endif
         .write_enable_o(we_retire),
         .mem_read_address_o(mem_read_address_int), 
         .mem_write_enable_o(mem_write_enable_retire),

--- a/rtl/branchPredict.sv
+++ b/rtl/branchPredict.sv
@@ -38,19 +38,19 @@ module branchPredict
 
     always_comb begin
         if (instruction_opcode_i == 7'h6f) begin
-            immediate               <= immediate_j_type_i;
-            inconditional_branch    <= 1'b1;
-            conditional_branch      <= 1'b0;
+            immediate               = immediate_j_type_i;
+            inconditional_branch    = 1'b1;
+            conditional_branch      = 1'b0;
         end
         else if (instruction_opcode_i == 7'h63) begin
-            immediate               <= immediate_b_type_i;
-            inconditional_branch    <= 1'b0;
-            conditional_branch      <= 1'b1;
+            immediate               = immediate_b_type_i;
+            inconditional_branch    = 1'b0;
+            conditional_branch      = 1'b1;
         end
         else begin
-            immediate               <= '0;
-            inconditional_branch    <= 1'b0;
-            conditional_branch      <= 1'b0;
+            immediate               = '0;
+            inconditional_branch    = 1'b0;
+            conditional_branch      = 1'b0;
         end
     end
 

--- a/rtl/branchPredict.sv
+++ b/rtl/branchPredict.sv
@@ -21,35 +21,40 @@ module branchPredict
 (
     input   logic [6:0]     instruction_opcode_i,
     input   logic           killed_i,
-    input   logic [31:0]    immediate_i,
+    input   logic [31:0]    immediate_b_type_i,
+    input   logic [31:0]    immediate_j_type_i,
     input   logic [31:0]    pc_i,
 
-    output  logic [31:0]    predict_branch_taken_o,
+    output  logic           predict_branch_taken_o,
     output  logic [31:0]    predict_branch_pc_o
 );
 
-    logic   inconditional_branch, conditional_branch;
-    logic   negative_offset, conditional_branch_taken;
+    logic           inconditional_branch, conditional_branch;
+    logic           negative_offset, conditional_branch_taken;
+    logic [31:0]    immediate;
 
     always_comb begin
         if (instruction_opcode_i == 7'h6f) begin
+            immediate               <= immediate_j_type_i;
             inconditional_branch    <= 1'b1;
             conditional_branch      <= 1'b0;
         end
         else if (instruction_opcode_i == 7'h63) begin
+            immediate               <= immediate_b_type_i;
             inconditional_branch    <= 1'b0;
             conditional_branch      <= 1'b1;
         end
         else begin
+            immediate               <= '0;
             inconditional_branch    <= 1'b0;
             conditional_branch      <= 1'b0;
         end
     end
 
-    assign negative_offset          = immediate_i[31];
-    assign conditional_branch_taken = conditional_branch   & negative_offset;
-    assign predict_branch_taken_o   = (inconditional_branch | conditional_branch_taken) & !killed_i;
+    assign negative_offset          = immediate[31];
+    assign conditional_branch_taken = conditional_branch && negative_offset;
+    assign predict_branch_taken_o   = (inconditional_branch || conditional_branch_taken) && !killed_i;
 
-    assign predict_branch_pc_o      = pc_i + immediate_i;
+    assign predict_branch_pc_o      = pc_i + immediate;
 
 endmodule

--- a/rtl/branchPredict.sv
+++ b/rtl/branchPredict.sv
@@ -20,10 +20,13 @@ module branchPredict
     import my_pkg::*;
 (
     input   logic [6:0]     instruction_opcode_i,
+    input   logic           hazard_i,
     input   logic           killed_i,
+    input   logic           jump_i,
     input   logic [31:0]    immediate_b_type_i,
     input   logic [31:0]    immediate_j_type_i,
     input   logic [31:0]    pc_i,
+    input   logic           predicted_r,
 
     output  logic           predict_branch_taken_o,
     output  logic [31:0]    predict_branch_pc_o
@@ -53,7 +56,7 @@ module branchPredict
 
     assign negative_offset          = immediate[31];
     assign conditional_branch_taken = conditional_branch && negative_offset;
-    assign predict_branch_taken_o   = (inconditional_branch || conditional_branch_taken) && !killed_i;
+    assign predict_branch_taken_o   = (inconditional_branch || conditional_branch_taken) && !predicted_r && !killed_i && !jump_i && !hazard_i;
 
     assign predict_branch_pc_o      = pc_i + immediate;
 

--- a/rtl/branchPredict.sv
+++ b/rtl/branchPredict.sv
@@ -1,0 +1,61 @@
+/*!\file BranchPredict.sv
+ * PUCRS-RV VERSION - 1.0 - Public Release
+ *
+ * Distribution:  May 2023
+ *
+ * Willian Nunes   <willian.nunes@edu.pucrs.br>
+ *
+ * Research group: GAPH-PUCRS  <>
+ *
+ * \brief
+ * Defines a Branch Prediction Mechanism.
+ *
+ * \detailed
+ * This implements static branch prediction. It takes an instruction and its PC and determines if
+ * it's a branch or a jump and calculates its target. For jumps it will always predict taken. For
+ * branches it will predict taken if the PC offset is negative.
+ */
+
+module branchPredict
+    import my_pkg::*;
+(
+    input   iType_e         instruction_operation_i,
+    input   logic           killed_i,
+    input   logic [31:0]    immediate_i,
+    input   logic [31:0]    pc_i,
+
+    output  logic [31:0]    predict_branch_taken_o,
+    output  logic [31:0]    predict_branch_pc_o
+);
+
+    logic   inconditional_branch, conditional_branch;
+    logic   negative_offset, conditional_branch_taken;
+
+    always_comb begin
+        if (executionUnit_e'(instruction_operation_i[5:3]) == BRANCH_UNIT) begin
+            if (instruction_operation_i == JAL) begin
+                inconditional_branch    <= 1'b1;
+                conditional_branch      <= 1'b0;
+            end
+            else if (instruction_operation_i == JALR) begin
+                inconditional_branch    <= 1'b0;
+                conditional_branch      <= 1'b0;
+            end
+            else begin
+                inconditional_branch    <= 1'b0;
+                conditional_branch      <= 1'b1;
+            end
+        end
+        else begin
+            inconditional_branch    <= 1'b0;
+            conditional_branch      <= 1'b0;
+        end
+    end
+
+    assign negative_offset          = immediate_i[31];
+    assign conditional_branch_taken = conditional_branch   & negative_offset;
+    assign predict_branch_taken_o   = (inconditional_branch | conditional_branch_taken) & !killed_i;
+
+    assign predict_branch_pc_o      = pc_i + immediate_i;
+
+endmodule

--- a/rtl/branchPredict.sv
+++ b/rtl/branchPredict.sv
@@ -19,7 +19,7 @@
 module branchPredict
     import my_pkg::*;
 (
-    input   iType_e         instruction_operation_i,
+    input   logic [6:0]     instruction_opcode_i,
     input   logic           killed_i,
     input   logic [31:0]    immediate_i,
     input   logic [31:0]    pc_i,
@@ -32,19 +32,13 @@ module branchPredict
     logic   negative_offset, conditional_branch_taken;
 
     always_comb begin
-        if (executionUnit_e'(instruction_operation_i[5:3]) == BRANCH_UNIT) begin
-            if (instruction_operation_i == JAL) begin
-                inconditional_branch    <= 1'b1;
-                conditional_branch      <= 1'b0;
-            end
-            else if (instruction_operation_i == JALR) begin
-                inconditional_branch    <= 1'b0;
-                conditional_branch      <= 1'b0;
-            end
-            else begin
-                inconditional_branch    <= 1'b0;
-                conditional_branch      <= 1'b1;
-            end
+        if (instruction_opcode_i == 7'h6f) begin
+            inconditional_branch    <= 1'b1;
+            conditional_branch      <= 1'b0;
+        end
+        else if (instruction_opcode_i == 7'h63) begin
+            inconditional_branch    <= 1'b0;
+            conditional_branch      <= 1'b1;
         end
         else begin
             inconditional_branch    <= 1'b0;

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -297,7 +297,7 @@ module decode
  */
     
     branchPredict branchPredict1 (
-        .instruction_operation_i(instruction_operation),
+        .instruction_opcode_i(instruction[6:0]),
         .killed_i(killed_i),
         .immediate_i(immediate),
         .pc_i(pc_i),

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -29,7 +29,7 @@ module decode
     input   logic           reset,
     input   logic           stall,
 
-    input   logic [31:0]    instruction_i,          // Object code of the instruction_int to extract the immediate operand
+    input   logic [31:0]    instruction_i,          // Object code of the instruction to extract the immediate operand
     input   logic [31:0]    pc_i,                   // Bypassed to execute unit as an operand
     input   logic [2:0]     tag_i,                  // Instruction tag_o
     input   logic [31:0]    rs1_data_read_i,        // Data read from register bank
@@ -49,32 +49,28 @@ module decode
     output  logic           exception_o
     );
 
-    logic [31:0] immediate, first_operand_int, second_operand_int, third_operand_int, instruction_int, last_instruction;
-    logic last_hazard;
-    logic [4:0] locked_registers[2];
-    logic [4:0] target_register;
-    logic is_store;
-    logic locked_memory[2];
+    logic   [31:0]  instruction, instruction_r;
+    formatType_e    instruction_format;
+    iType_e         instruction_operation;
+    logic   [31:0]  immediate, first_operand_int, second_operand_int, third_operand_int;
+    logic           hazard_r;
+    logic   [4:0]   locked_registers[2];
+    logic   [4:0]   target_register;
+    logic           is_store;
+    logic           locked_memory[2];
 
-    formatType_e instruction_format;
-    iType_e instruction_operation;
+    logic           inconditional_branch, conditional_branch;
+    logic           negative_offset, conditional_branch_taken, predict_branch_taken_o, predict_branch_pc_o;
 
 //////////////////////////////////////////////////////////////////////////////
-// Re-Decode isntruction on hazard
+// Re-Decode instruction on hazard
 //////////////////////////////////////////////////////////////////////////////
+
+    assign instruction = (hazard_r) ? instruction_r : instruction_i;
 
     always_ff @(posedge clk ) begin
-        last_instruction <= instruction_int;
-        last_hazard      <= hazard_o;
-    end
-
-    always_comb begin
-        if (last_hazard) begin
-            instruction_int = last_instruction;
-        end
-        else begin
-            instruction_int = instruction_i;
-        end
+        instruction_r <= instruction;
+        hazard_r      <= hazard_o;
     end
 
 //////////////////////////////////////////////////////////////////////////////
@@ -82,69 +78,69 @@ module decode
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin 
-        if (instruction_int[6:0] == 7'b0110111) instruction_operation = LUI;
-        else if (instruction_int[6:0] == 7'b0010111) instruction_operation = ADD;    //AUIPC
+        if (instruction[6:0] == 7'b0110111) instruction_operation = LUI;
+        else if (instruction[6:0] == 7'b0010111) instruction_operation = ADD;    //AUIPC
         
-        else if (instruction_int[6:0] == 7'b1101111) instruction_operation = JAL;
-        else if (instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b1100111) instruction_operation = JALR;
+        else if (instruction[6:0] == 7'b1101111) instruction_operation = JAL;
+        else if (instruction[14:12] == 3'b000 && instruction[6:0] == 7'b1100111) instruction_operation = JALR;
 
-        else if (instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b1100011) instruction_operation = BEQ;
-        else if (instruction_int[14:12] == 3'b001 && instruction_int[6:0] == 7'b1100011) instruction_operation = BNE;
-        else if (instruction_int[14:12] == 3'b100 && instruction_int[6:0] == 7'b1100011) instruction_operation = BLT;
-        else if (instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b1100011) instruction_operation = BGE;
-        else if (instruction_int[14:12] == 3'b110 && instruction_int[6:0] == 7'b1100011) instruction_operation = BLTU;
-        else if (instruction_int[14:12] == 3'b111 && instruction_int[6:0] == 7'b1100011) instruction_operation = BGEU;
+        else if (instruction[14:12] == 3'b000 && instruction[6:0] == 7'b1100011) instruction_operation = BEQ;
+        else if (instruction[14:12] == 3'b001 && instruction[6:0] == 7'b1100011) instruction_operation = BNE;
+        else if (instruction[14:12] == 3'b100 && instruction[6:0] == 7'b1100011) instruction_operation = BLT;
+        else if (instruction[14:12] == 3'b101 && instruction[6:0] == 7'b1100011) instruction_operation = BGE;
+        else if (instruction[14:12] == 3'b110 && instruction[6:0] == 7'b1100011) instruction_operation = BLTU;
+        else if (instruction[14:12] == 3'b111 && instruction[6:0] == 7'b1100011) instruction_operation = BGEU;
 
-        else if (instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b0000011) instruction_operation = LB;
-        else if (instruction_int[14:12] == 3'b001 && instruction_int[6:0] == 7'b0000011) instruction_operation = LH;
-        else if (instruction_int[14:12] == 3'b010 && instruction_int[6:0] == 7'b0000011) instruction_operation = LW;
-        else if (instruction_int[14:12] == 3'b100 && instruction_int[6:0] == 7'b0000011) instruction_operation = LBU;
-        else if (instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b0000011) instruction_operation = LHU;
+        else if (instruction[14:12] == 3'b000 && instruction[6:0] == 7'b0000011) instruction_operation = LB;
+        else if (instruction[14:12] == 3'b001 && instruction[6:0] == 7'b0000011) instruction_operation = LH;
+        else if (instruction[14:12] == 3'b010 && instruction[6:0] == 7'b0000011) instruction_operation = LW;
+        else if (instruction[14:12] == 3'b100 && instruction[6:0] == 7'b0000011) instruction_operation = LBU;
+        else if (instruction[14:12] == 3'b101 && instruction[6:0] == 7'b0000011) instruction_operation = LHU;
 
-        else if (instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b0100011) instruction_operation = SB;
-        else if (instruction_int[14:12] == 3'b001 && instruction_int[6:0] == 7'b0100011) instruction_operation = SH;
-        else if (instruction_int[14:12] == 3'b010 && instruction_int[6:0] == 7'b0100011) instruction_operation = SW;
+        else if (instruction[14:12] == 3'b000 && instruction[6:0] == 7'b0100011) instruction_operation = SB;
+        else if (instruction[14:12] == 3'b001 && instruction[6:0] == 7'b0100011) instruction_operation = SH;
+        else if (instruction[14:12] == 3'b010 && instruction[6:0] == 7'b0100011) instruction_operation = SW;
         
-        else if (instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b0010011) instruction_operation = ADD;     // ADDI
-        else if (instruction_int[14:12] == 3'b010 && instruction_int[6:0] == 7'b0010011) instruction_operation = SLT;     // SLTI
-        else if (instruction_int[14:12] == 3'b011 && instruction_int[6:0] == 7'b0010011) instruction_operation = SLTU;    // SLTIU
-        else if (instruction_int[14:12] == 3'b100 && instruction_int[6:0] == 7'b0010011) instruction_operation = XOR;     // XORI
-        else if (instruction_int[14:12] == 3'b110 && instruction_int[6:0] == 7'b0010011) instruction_operation = OR;      // ORI
-        else if (instruction_int[14:12] == 3'b111 && instruction_int[6:0] == 7'b0010011) instruction_operation = AND;     // ANDI
+        else if (instruction[14:12] == 3'b000 && instruction[6:0] == 7'b0010011) instruction_operation = ADD;     // ADDI
+        else if (instruction[14:12] == 3'b010 && instruction[6:0] == 7'b0010011) instruction_operation = SLT;     // SLTI
+        else if (instruction[14:12] == 3'b011 && instruction[6:0] == 7'b0010011) instruction_operation = SLTU;    // SLTIU
+        else if (instruction[14:12] == 3'b100 && instruction[6:0] == 7'b0010011) instruction_operation = XOR;     // XORI
+        else if (instruction[14:12] == 3'b110 && instruction[6:0] == 7'b0010011) instruction_operation = OR;      // ORI
+        else if (instruction[14:12] == 3'b111 && instruction[6:0] == 7'b0010011) instruction_operation = AND;     // ANDI
 
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b001 && instruction_int[6:0] == 7'b0010011) instruction_operation = SLL;    // SLLI
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b0010011) instruction_operation = SRL;    // SRLI
-        else if (instruction_int[31:25] == 7'b0100000 && instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b0010011) instruction_operation = SRA;    // SRAI
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b001 && instruction[6:0] == 7'b0010011) instruction_operation = SLL;    // SLLI
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b101 && instruction[6:0] == 7'b0010011) instruction_operation = SRL;    // SRLI
+        else if (instruction[31:25] == 7'b0100000 && instruction[14:12] == 3'b101 && instruction[6:0] == 7'b0010011) instruction_operation = SRA;    // SRAI
 
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b0110011) instruction_operation = ADD;
-        else if (instruction_int[31:25] == 7'b0100000 && instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b0110011) instruction_operation = SUB;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b001 && instruction_int[6:0] == 7'b0110011) instruction_operation = SLL;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b010 && instruction_int[6:0] == 7'b0110011) instruction_operation = SLT;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b011 && instruction_int[6:0] == 7'b0110011) instruction_operation = SLTU;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b100 && instruction_int[6:0] == 7'b0110011) instruction_operation = XOR;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b0110011) instruction_operation = SRL;
-        else if (instruction_int[31:25] == 7'b0100000 && instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b0110011) instruction_operation = SRA;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b110 && instruction_int[6:0] == 7'b0110011) instruction_operation = OR;
-        else if (instruction_int[31:25] == 7'b0000000 && instruction_int[14:12] == 3'b111 && instruction_int[6:0] == 7'b0110011) instruction_operation = AND;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b000 && instruction[6:0] == 7'b0110011) instruction_operation = ADD;
+        else if (instruction[31:25] == 7'b0100000 && instruction[14:12] == 3'b000 && instruction[6:0] == 7'b0110011) instruction_operation = SUB;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b001 && instruction[6:0] == 7'b0110011) instruction_operation = SLL;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b010 && instruction[6:0] == 7'b0110011) instruction_operation = SLT;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b011 && instruction[6:0] == 7'b0110011) instruction_operation = SLTU;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b100 && instruction[6:0] == 7'b0110011) instruction_operation = XOR;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b101 && instruction[6:0] == 7'b0110011) instruction_operation = SRL;
+        else if (instruction[31:25] == 7'b0100000 && instruction[14:12] == 3'b101 && instruction[6:0] == 7'b0110011) instruction_operation = SRA;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b110 && instruction[6:0] == 7'b0110011) instruction_operation = OR;
+        else if (instruction[31:25] == 7'b0000000 && instruction[14:12] == 3'b111 && instruction[6:0] == 7'b0110011) instruction_operation = AND;
 
-        else if (instruction_int[14:12] == 3'b000 && instruction_int[6:0] == 7'b0001111) instruction_operation = NOP;          // FENCE
+        else if (instruction[14:12] == 3'b000 && instruction[6:0] == 7'b0001111) instruction_operation = NOP;          // FENCE
 
-        else if (instruction_int[14:12] == 3'b001 && instruction_int[6:0] == 7'b1110011) instruction_operation = CSRRW;
-        else if (instruction_int[14:12] == 3'b010 && instruction_int[6:0] == 7'b1110011) instruction_operation = CSRRS;
-        else if (instruction_int[14:12] == 3'b011 && instruction_int[6:0] == 7'b1110011) instruction_operation = CSRRC;
-        else if (instruction_int[14:12] == 3'b101 && instruction_int[6:0] == 7'b1110011) instruction_operation = CSRRWI;
-        else if (instruction_int[14:12] == 3'b110 && instruction_int[6:0] == 7'b1110011) instruction_operation = CSRRSI;
-        else if (instruction_int[14:12] == 3'b111 && instruction_int[6:0] == 7'b1110011) instruction_operation = CSRRCI;
+        else if (instruction[14:12] == 3'b001 && instruction[6:0] == 7'b1110011) instruction_operation = CSRRW;
+        else if (instruction[14:12] == 3'b010 && instruction[6:0] == 7'b1110011) instruction_operation = CSRRS;
+        else if (instruction[14:12] == 3'b011 && instruction[6:0] == 7'b1110011) instruction_operation = CSRRC;
+        else if (instruction[14:12] == 3'b101 && instruction[6:0] == 7'b1110011) instruction_operation = CSRRWI;
+        else if (instruction[14:12] == 3'b110 && instruction[6:0] == 7'b1110011) instruction_operation = CSRRSI;
+        else if (instruction[14:12] == 3'b111 && instruction[6:0] == 7'b1110011) instruction_operation = CSRRCI;
 
-        else if (instruction_int[31:0] == 32'h00000073) instruction_operation = ECALL;
-        else if (instruction_int[31:0] == 32'h00100073) instruction_operation = EBREAK;
+        else if (instruction[31:0] == 32'h00000073) instruction_operation = ECALL;
+        else if (instruction[31:0] == 32'h00100073) instruction_operation = EBREAK;
 
-        else if (instruction_int[31:0] == 32'h10200073) instruction_operation = SRET;
-        else if (instruction_int[31:0] == 32'h30200073) instruction_operation = MRET;
+        else if (instruction[31:0] == 32'h10200073) instruction_operation = SRET;
+        else if (instruction[31:0] == 32'h30200073) instruction_operation = MRET;
 
-        else if (instruction_int[31:0] == 32'h10500073) instruction_operation = WFI;
+        else if (instruction[31:0] == 32'h10500073) instruction_operation = WFI;
 
-        else if (instruction_int[31:0] == 32'h00000013) instruction_operation = NOP;
+        else if (instruction[31:0] == 32'h00000013) instruction_operation = NOP;
 
         else instruction_operation = INVALID;
     end
@@ -154,7 +150,7 @@ module decode
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin
-        case (instruction_int[6:0])
+        case (instruction[6:0])
             7'b0010011, 7'b1100111, 7'b0000011:     instruction_format = I_TYPE;
             7'b0100011:                             instruction_format = S_TYPE;
             7'b1100011:                             instruction_format = B_TYPE;
@@ -171,43 +167,43 @@ module decode
     always_comb begin
         case (instruction_format)
             I_TYPE: begin
-                        immediate[31:11] = (!instruction_int[31]) 
+                        immediate[31:11] = (!instruction[31]) 
                                             ? '0 
                                             : '1;
-                        immediate[10:0]  = instruction_int[30:20];
+                        immediate[10:0]  = instruction[30:20];
                     end
 
             S_TYPE: begin
-                        immediate[31:11] = (!instruction_int[31]) 
+                        immediate[31:11] = (!instruction[31]) 
                                             ? '0 
                                             : '1;
-                        immediate[10:5]  = instruction_int[30:25];
-                        immediate[4:0]   = instruction_int[11:7];
+                        immediate[10:5]  = instruction[30:25];
+                        immediate[4:0]   = instruction[11:7];
                     end
 
             B_TYPE: begin
-                        immediate[31:12] = (!instruction_int[31]) 
+                        immediate[31:12] = (!instruction[31]) 
                                             ? '0 
                                             : '1;
-                        immediate[11]    = instruction_int[7];
-                        immediate[10:5]  = instruction_int[30:25];
-                        immediate[4:1]   = instruction_int[11:8];
+                        immediate[11]    = instruction[7];
+                        immediate[10:5]  = instruction[30:25];
+                        immediate[4:1]   = instruction[11:8];
                         immediate[0]     = 0;
                     end
 
             U_TYPE: begin
-                        immediate[31:12] = instruction_int[31:12];
+                        immediate[31:12] = instruction[31:12];
                         immediate[11:0]  = '0;
                     end
 
             J_TYPE: begin
-                        immediate[31:20] = (!instruction_int[31]) 
+                        immediate[31:20] = (!instruction[31]) 
                                             ? '0 
                                             : '1;
-                        immediate[19:12] = instruction_int[19:12];
-                        immediate[11]    = instruction_int[20];
-                        immediate[10:5]  = instruction_int[30:25];
-                        immediate[4:1]   = instruction_int[24:21];
+                        immediate[19:12] = instruction[19:12];
+                        immediate[11]    = instruction[20];
+                        immediate[10:5]  = instruction[30:25];
+                        immediate[4:1]   = instruction[24:21];
                         immediate[0]     = 0;
                     end
 
@@ -219,8 +215,8 @@ module decode
 // Addresses to RegBank
 //////////////////////////////////////////////////////////////////////////////
 
-    assign rs1_o = instruction_int[19:15];
-    assign rs2_o = instruction_int[24:20];
+    assign rs1_o = instruction[19:15];
+    assign rs2_o = instruction[24:20];
     assign rd_o  = locked_registers[1];
 
 //////////////////////////////////////////////////////////////////////////////
@@ -229,7 +225,7 @@ module decode
 
     always_comb begin
         if (!hazard_o) begin
-            target_register = instruction_int[11:7];
+            target_register = instruction[11:7];
             ///////////////////////////////////
             if (instruction_operation == SB || instruction_operation == SH || instruction_operation == SW) begin
                 is_store = 1;
@@ -283,6 +279,36 @@ module decode
     end
 
 //////////////////////////////////////////////////////////////////////////////
+// Branch Prediction
+//////////////////////////////////////////////////////////////////////////////
+/*
+ * This implements static branch prediction. It takes an instruction and its PC and determines if
+ * it's a branch or a jump and calculates its target. For jumps it will always predict taken. For
+ * branches it will predict taken if the PC offset is negative.
+ */
+    always_comb begin
+        if (executionUnit_e'(instruction_operation[5:3]) == BRANCH_UNIT) begin
+            if (instruction_operation == JAL || instruction_operation == JALR) begin
+                inconditional_branch    <= 1'b1;
+                conditional_branch      <= 1'b0;
+            end
+            else begin
+                inconditional_branch    <= 1'b0;
+                conditional_branch      <= 1'b1;
+            end
+        end
+        else begin
+            inconditional_branch    <= 1'b0;
+            conditional_branch      <= 1'b0;
+        end
+    end
+
+    assign negative_offset          = immediate[31];
+    assign conditional_branch_taken = conditional_branch   & negative_offset;
+    assign predict_branch_taken_o   = inconditional_branch | conditional_branch_taken;
+    assign predict_branch_pc_o      = pc_i + immediate;
+
+//////////////////////////////////////////////////////////////////////////////
 // Control of the exits based on format
 //////////////////////////////////////////////////////////////////////////////
 
@@ -306,44 +332,44 @@ module decode
 
     always_ff @(posedge clk) begin
         if (reset) begin
-            first_operand_o  <= '0;
-            second_operand_o <= '0;
-            third_operand_o  <= '0;
-            pc_o             <= '0;
-            instruction_o    <= '0;
+            first_operand_o         <= '0;
+            second_operand_o        <= '0;
+            third_operand_o         <= '0;
+            pc_o                    <= '0;
+            instruction_o           <= '0;
             instruction_operation_o <= NOP;
-            tag_o            <= '0;
-            exception_o      <= 0;
+            tag_o                   <= '0;
+            exception_o             <= 0;
         end 
         else if (stall) begin
-            first_operand_o   <= first_operand_o;
-            second_operand_o  <= second_operand_o;
-            third_operand_o   <= third_operand_o;
-            pc_o              <= pc_o;
-            instruction_o     <= instruction_o;
+            first_operand_o         <= first_operand_o;
+            second_operand_o        <= second_operand_o;
+            third_operand_o         <= third_operand_o;
+            pc_o                    <= pc_o;
+            instruction_o           <= instruction_o;
             instruction_operation_o <= instruction_operation_o;
-            tag_o             <= tag_o;
-            exception_o       <= exception_o;
+            tag_o                   <= tag_o;
+            exception_o             <= exception_o;
         end 
         else if (hazard_o) begin
-            first_operand_o  <= '0;
-            second_operand_o <= '0;
-            third_operand_o  <= '0;
-            pc_o             <= '0;
-            instruction_o    <= '0;
+            first_operand_o         <= '0;
+            second_operand_o        <= '0;
+            third_operand_o         <= '0;
+            pc_o                    <= '0;
+            instruction_o           <= '0;
             instruction_operation_o <= NOP;
-            tag_o            <= tag_i;
-            exception_o      <= 0;
+            tag_o                   <= tag_i;
+            exception_o             <= 0;
         end 
         else if (!stall) begin
-            first_operand_o  <= first_operand_int;
-            second_operand_o <= second_operand_int;
-            third_operand_o  <= third_operand_int;
-            pc_o             <= pc_i;
-            instruction_o    <= instruction_int;
+            first_operand_o         <= first_operand_int;
+            second_operand_o        <= second_operand_int;
+            third_operand_o         <= third_operand_int;
+            pc_o                    <= pc_i;
+            instruction_o           <= instruction;
             instruction_operation_o <= instruction_operation;
-            tag_o            <= tag_i;
-            exception_o      <= (instruction_operation==INVALID) ? 1 : 0;
+            tag_o                   <= tag_i;
+            exception_o             <= (instruction_operation==INVALID) ? 1 : 0;
         end
     end
 

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -296,7 +296,7 @@ module decode
  * branches it will predict taken if the PC offset is negative.
  */
     
-    branchPredict1 branchPredict (
+    branchPredict branchPredict1 (
         .instruction_operation_i(instruction_operation),
         .killed_i(killed_i),
         .immediate_i(immediate),

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -36,6 +36,7 @@ module decode
     input   logic [31:0]    rs2_data_read_i,        // Data read from register bank
 
 `ifdef BRANCH_PREDICTION
+    input   logic           jump_i,
     input   logic           killed_i,
     output  logic           predicted_branch_o,
     output  logic           predict_branch_taken_o,
@@ -306,10 +307,13 @@ module decode
     
     branchPredict branchPredict1 (
         .instruction_opcode_i(instruction[6:0]),
+        .hazard_i(hazard_o),
         .killed_i(killed_i),
+        .jump_i(jump_i),
         .immediate_b_type_i(imm_b_type),
         .immediate_j_type_i(imm_j_type),
         .pc_i(pc_i),
+        .predicted_r(predicted_branch_o),
 
         .predict_branch_taken_o(predict_branch_taken),
         .predict_branch_pc_o(predict_branch_pc_o)

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -35,7 +35,11 @@ module execute
     input   logic [31:0]   third_operand_i,    //              ||
     input   iType_e        instruction_operation_i,
     input   logic [2:0]    tag_i,              // Instruction tag
+
+`ifdef BRANCH_PREDICTION
     input   logic          predicted_branch_i,
+    output  logic          predicted_branch_o,
+`endif
 
     output  iType_e        instruction_operation_o,
     output  logic [31:0]   instruction_o,
@@ -44,7 +48,6 @@ module execute
     output  logic [2:0]    tag_o,              // Instruction tag
     output  logic          jump_o,             // Signal that indicates a branch taken
     output  logic          write_enable_o,     // Write enable to regbank
-    output  logic          predicted_branch_o,
 
 
     output  logic [31:0]   mem_read_address_o, // Memory Read Address
@@ -223,11 +226,14 @@ module execute
     always_ff @(posedge clk) begin
         if (!stall) begin
             tag_o                   <= tag_i;
-            predicted_branch_o      <= predicted_branch_i;
             instruction_operation_o <= instruction_operation_i;
             instruction_o           <= instruction_i;
             pc_o                    <= pc_i;
             exception_o             <= exception_i | csr_exception;
+        
+        `ifdef BRANCH_PREDICTION
+            predicted_branch_o      <= predicted_branch_i;
+        `endif
         end
     end
 

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -35,6 +35,7 @@ module execute
     input   logic [31:0]   third_operand_i,    //              ||
     input   iType_e        instruction_operation_i,
     input   logic [2:0]    tag_i,              // Instruction tag
+    input   logic          predicted_branch_i,
 
     output  iType_e        instruction_operation_o,
     output  logic [31:0]   instruction_o,
@@ -43,6 +44,8 @@ module execute
     output  logic [2:0]    tag_o,              // Instruction tag
     output  logic          jump_o,             // Signal that indicates a branch taken
     output  logic          write_enable_o,     // Write enable to regbank
+    output  logic          predicted_branch_o,
+
 
     output  logic [31:0]   mem_read_address_o, // Memory Read Address
     output  logic [3:0]    mem_write_enable_o, // Signal that indicates the write memory operation to retire
@@ -220,6 +223,7 @@ module execute
     always_ff @(posedge clk) begin
         if (!stall) begin
             tag_o                   <= tag_i;
+            predicted_branch_o      <= predicted_branch_i;
             instruction_operation_o <= instruction_operation_i;
             instruction_o           <= instruction_i;
             pc_o                    <= pc_i;

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -20,7 +20,10 @@
  * in regular flows, the tag leaves the unit with the instruction fetched.
  */
 
-module fetch  #(parameter start_address = 32'b0)(  //Generic start address
+module fetch  
+import my_pkg::*;
+#(parameter start_address = 32'b0)
+(
     input   logic           clk,
     input   logic           reset,
     input   logic           stall,

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -60,11 +60,11 @@ module fetch  #(parameter start_address = 32'b0)(  //Generic start address
         else if (exception_raised_i || interrupt_ack_i) begin                               
             pc <= mtvec_i;
         end
-        else if (predict_branch_taken_i) begin
-            pc <= predict_branch_pc_i + 4;
-        end
         else if (jump_i) begin
             pc <= jump_target_i;
+        end
+        else if (predict_branch_taken_i) begin
+            pc <= predict_branch_pc_i + 4;
         end
         else if (!hazard_i && !stall) begin
             pc <= pc_plus4;
@@ -79,7 +79,9 @@ module fetch  #(parameter start_address = 32'b0)(  //Generic start address
 
     always_ff @(posedge clk) begin
         if (!hazard_i && !stall) begin
-            pc_o <= pc;
+            pc_o <= (predict_branch_taken_i)
+                    ? predict_branch_pc_i
+                    : pc;
         end
     end
 
@@ -91,20 +93,17 @@ module fetch  #(parameter start_address = 32'b0)(  //Generic start address
                                     ? predict_branch_pc_i 
                                     : pc;
 
-    assign tag_o =  (predict_branch_taken_i) 
-                    ? current_tag + 1
-                    : current_tag;
+    assign tag_o = current_tag;
 
 //////////////////////////////////////////////////////////////////////////////
 // TAG Calculator 
 //////////////////////////////////////////////////////////////////////////////
-
     always_ff @(posedge clk) begin
         if (reset) begin
             current_tag <= 0;
             next_tag <= 0;
         end
-        else if (jump_i || exception_raised_i || machine_return_i || interrupt_ack_i || predict_branch_taken_i) begin
+        else if (jump_i || exception_raised_i || machine_return_i || interrupt_ack_i) begin
             next_tag <= current_tag + 1;
         end
         else if (!hazard_i && !stall) begin

--- a/rtl/my_pkg.sv
+++ b/rtl/my_pkg.sv
@@ -19,6 +19,10 @@
 
 package my_pkg;
 
+    // `define PROTO 1
+    // `define DEBUG 1
+    `define BRANCH_PREDICTION 1
+
     typedef enum  logic[2:0] {R_TYPE, I_TYPE, S_TYPE, B_TYPE, U_TYPE, J_TYPE} formatType_e;
 
     typedef enum  logic[2:0] {

--- a/rtl/retire.sv
+++ b/rtl/retire.sv
@@ -82,15 +82,21 @@ module retire
 //////////////////////////////////////////////////////////////////////////////
 // Killed signal generation
 //////////////////////////////////////////////////////////////////////////////
+    logic jump_r;
+    
     assign killed_o = killed;
     
     always_comb begin
-        if (curr_tag != tag_i) begin
+        if (curr_tag != tag_i || jump_r) begin
             killed = 1;
         end
         else begin
             killed = 0;
         end
+    end
+
+    always_ff @(posedge clk) begin
+        jump_r <= jump_o;
     end
 
 //////////////////////////////////////////////////////////////////////////////

--- a/rtl/retire.sv
+++ b/rtl/retire.sv
@@ -36,6 +36,7 @@ module retire
     input   logic [3:0]     mem_write_enable_i,         // Write enable memory
     input   logic           write_enable_i,             // Write enable from Execute(based on instruction_i type)
     input   logic           jump_i,                     // Jump signal from branch unit 
+    input   logic           predicted_branch_i,
     input   iType_e         instruction_operation_i,
     input   logic           exception_i,
 
@@ -102,7 +103,7 @@ module retire
     end
 
 //////////////////////////////////////////////////////////////////////////////
-// RegBank Writw Enable Generation
+// RegBank Write Enable Generation
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin
@@ -119,13 +120,17 @@ module retire
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin
-        if (jump_i && !killed) begin
-            jump_target_o = results_i[1];
-            jump_o        = 1;
-        end 
+        if (jump_i && !predicted_branch_i && !killed) begin
+            jump_o          = 1;
+            jump_target_o   = results_i[1];
+        end
+        else if (!jump_i && predicted_branch_i && !killed) begin
+            jump_o          = 1;
+            jump_target_o   = pc_i;
+        end
         else begin
-            jump_target_o = '0;
-            jump_o        = '0;
+            jump_o          = 0;
+            jump_target_o   = '0;
         end
     end
 

--- a/rtl/retire.sv
+++ b/rtl/retire.sv
@@ -120,14 +120,17 @@ module retire
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin
+        // If should have jumped and predicted not jump then jump
         if (jump_i && !predicted_branch_i && !killed) begin
             jump_o          = 1;
             jump_target_o   = results_i[1];
         end
+        // If should not have jumped and predicted jump then return
         else if (!jump_i && predicted_branch_i && !killed) begin
             jump_o          = 1;
             jump_target_o   = pc_i;
         end
+        // Predicted Right or not a Jump
         else begin
             jump_o          = 0;
             jump_target_o   = '0;

--- a/rtl/retire.sv
+++ b/rtl/retire.sv
@@ -36,9 +36,12 @@ module retire
     input   logic [3:0]     mem_write_enable_i,         // Write enable memory
     input   logic           write_enable_i,             // Write enable from Execute(based on instruction_i type)
     input   logic           jump_i,                     // Jump signal from branch unit 
-    input   logic           predicted_branch_i,
     input   iType_e         instruction_operation_i,
     input   logic           exception_i,
+
+`ifdef BRANCH_PREDICTION
+    input   logic           predicted_branch_i,
+`endif
 
     output  logic           regbank_write_enable_o,     // Write Enable to Register Bank
     output  logic [31:0]    regbank_data_o,             // WriteBack data to Register Bank
@@ -118,7 +121,7 @@ module retire
 //////////////////////////////////////////////////////////////////////////////
 // PC Flow control signal generation
 //////////////////////////////////////////////////////////////////////////////
-
+`ifdef BRANCH_PREDICTION
     always_comb begin
         // If should have jumped and predicted not jump then jump
         if (jump_i && !predicted_branch_i && !killed) begin
@@ -136,6 +139,18 @@ module retire
             jump_target_o   = '0;
         end
     end
+`else
+    always_comb begin
+        if (jump_i && !killed) begin
+            jump_o        = 1;
+            jump_target_o = results_i[1];
+        end 
+        else begin
+            jump_o        = '0;
+            jump_target_o = '0;
+        end
+    end
+`endif
 
 //////////////////////////////////////////////////////////////////////////////
 // Memory Signal Generation

--- a/sim/testbench.sv
+++ b/sim/testbench.sv
@@ -25,6 +25,7 @@
 `include "../rtl/xus/logicUnit.sv"
 `include "../rtl/xus/LSUnit.sv"
 `include "../rtl/xus/shiftUnit.sv"
+`include "../rtl/branchPredict.sv"
 `include "../rtl/fetch.sv"
 `include "../rtl/decode.sv"
 `include "../rtl/execute.sv"


### PR DESCRIPTION
This implements static branch prediction. It takes an instruction and its PC and determines if
it's a branch or a jump and calculates its target. For jumps it will always predict taken. For
branches it will predict taken if the PC offset is negative.

Improved performance by about 14%. 

Coremark ticks for an iteration
W/o  Branch Prediction  --> 13090
With Branch Prediction  -->  11467

Coremark Iterations per second
W/o  Branch Prediction  --> 76
With Branch Prediction  -->  87

Normalized performance score is now 0.872 iterations/Mhz, this is similar to IBex core that has a normalized performance score of about 0.904 Iterations/Mhz.

Comparing with 1.0.0 version (TCC release) that presented 0.670 Iterations/Mhz the RS5 core improved a lot in performance until now (about 30%) with branch prediction mechanism and with one stage forwarding.